### PR TITLE
fix(layout): ensure main content scrolls independently of sidebar

### DIFF
--- a/src/pages/admin/AdminLayout.jsx
+++ b/src/pages/admin/AdminLayout.jsx
@@ -6,7 +6,7 @@ import { Outlet } from "react-router-dom";
 const AdminLayout = () => (
   <div className="flex min-h-screen">
     <AdminSidebar />
-    <main className="flex-1 bg-gray-50">
+    <main className="flex-1 bg-gray-50 w-0 overflow-x-auto">
       <Outlet />
     </main>
   </div>


### PR DESCRIPTION
# fix(layout): ensure main content scrolls independently of sidebar

## Summary
This PR resolves a layout issue where a wide table on the "Purchase Requisition Details" page caused the entire page, including the sidebar, to scroll horizontally. The fix ensures that only the main content area is scrollable, keeping the sidebar fixed and always visible.

## Root Cause
The main content area, a flexbox item with `flex-1`, was not configured to handle its own overflow. As a result, it expanded to the width of its widest child (the table), which pushed the boundaries of the entire page and caused the `<body>` to scroll.

## Changes
- Modified `src/pages/admin/AdminLayout.jsx`.
- Added the Tailwind CSS classes `w-0` and `overflow-x-auto` to the `<main>` element.

## Screen Recording
Here is a screen recording demonstrating that the sidebar now remains fixed while the main content area scrolls as intended.


https://github.com/user-attachments/assets/259e2fc7-a578-4c17-85a4-d21eea058fe8



## Testing
- Cloned the repository and installed dependencies with `npm install`.
- Started the development server using `npm run dev`.
- Navigated to the Purchase Requisition page.
- Resized the browser window to a narrow width to confirm that a horizontal scrollbar appears only on the main content area, and the sidebar remains static.

## Risk & Rollback
- **Risk**: Low. This is a targeted layout change confined to the main admin layout wrapper.
- **Rollback**: This change can be reverted by removing the `w-0` and `overflow-x-auto` classes from the `<main>` element in `AdminLayout.jsx`.

## Related
- Closes #12